### PR TITLE
Small touchups to definition files

### DIFF
--- a/oepl-definitions.h
+++ b/oepl-definitions.h
@@ -1,3 +1,5 @@
+#ifndef OEPL_DEFINITIONS_H
+#define OEPL_DEFINITIONS_H
 
 // OEPL TAG TYPES
 // The 'OG' tags in OEPL (mostly M2 tags)
@@ -179,3 +181,5 @@
 #define TAG_CUSTOM_SLIDESHOW_SLOW 0x08
 #define TAG_CUSTOM_SLIDESHOW_GLACIAL 0x09
 #define TAG_CUSTOM_MODE_WAIT_RFWAKE 0x20
+
+#endif

--- a/oepl-definitions.h
+++ b/oepl-definitions.h
@@ -174,6 +174,10 @@
 #define CUSTOM_IMAGE_RF_WAKE 0x1C
 #define CUSTOM_IMAGE_GPIO 0x1D
 #define CUSTOM_IMAGE_NFC_WAKE 0x1E
+// Bit 5 is used as flag to indicate preload instead of immediate display
+#define CUSTOM_IMAGE_PRELOAD_FLAG 0x20
+// Bits 6-7 are allocated to select a custom LUT for this image
+#define CUSTOM_IMAGE_LUT_MASK 0xC0
 
 #define TAG_CUSTOM_MODE_NONE 0x00
 #define TAG_CUSTOM_SLIDESHOW_FAST 0x06

--- a/oepl-esp-ap-proto.h
+++ b/oepl-esp-ap-proto.h
@@ -1,3 +1,6 @@
+#ifndef OEPL_ESP_AP_PROTO_H
+#define OEPL_ESP_AP_PROTO_H
+
 #ifndef __packed
 #define __packed __attribute__((packed))
 #endif
@@ -36,3 +39,4 @@ struct espTagReturnData {
     struct tagReturnData returnData;
 } __packed;
 
+#endif

--- a/oepl-proto.h
+++ b/oepl-proto.h
@@ -1,3 +1,5 @@
+#ifndef OEPL_PROTO_H
+#define OEPL_PROTO_H
 
 #ifndef __packed
 #define __packed __attribute__((packed))
@@ -194,3 +196,5 @@ struct imageDataTypeArgStruct {
     uint8_t preloadImage : 1;  // set to 0 will draw image immediately
     uint8_t specialType : 5;
 } __packed;
+
+#endif


### PR DESCRIPTION
1. Added header guards against recursive inclusion
2. Added definition of the three upper bits in the custom image type, which weren't declared as bitmask/flag yet, only as C-struct in https://github.com/OpenEPaperLink/Shared_OEPL_Definitions/blob/2ea5cc912acbb2fe5bcb5fad2ef0ff89167366d2/oepl-proto.h#L192-L196